### PR TITLE
Remove `replace-namespace.sh` once the job is done

### DIFF
--- a/replace-namespace.sh
+++ b/replace-namespace.sh
@@ -19,4 +19,4 @@ find "$SCRIPT_DIR" -type f \( -name "*.php" -o -name "*.json" \) ! -name "$SCRIP
 	perl -pi -e "s/WP_Compat_Validation_Tool/$NEW_NAMESPACE/g" "$file"
 done
 
-cd 10up-lib/wp-compat-validation-tool && rm -rf .git .github .gitignore composer.json composer.lock CHANGELOG.md CONTRIBUTING.md README.md LICENSE.md CODE_OF_CONDUCT.md CREDITS.md
+cd 10up-lib/wp-compat-validation-tool && rm -rf .git .github .gitignore composer.json composer.lock CHANGELOG.md CONTRIBUTING.md README.md LICENSE.md CODE_OF_CONDUCT.md CREDITS.md replace-namespace.sh


### PR DESCRIPTION
### Description of the Change

This PR updates the `replace-namespace.sh` script to remove itself from the `10up-lib/wp-compat-validation-tool` directory after the namespace replacement is complete. This ensures that unnecessary files are not included in production or distributed plugin builds as reported at https://github.com/10up/simple-local-avatars/issues/322. We then have no need to update `.distignore` or rely on manual cleanup.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/simple-local-avatars/issues/322

### How to test the Change

Not exactly know how to test this in the active repository, but this is how I tested it locally:

1. Run the updated `replace-namespace.sh` script with a namespace argument.
2. Confirm that the namespace replacement occurs as expected.
3. Confirm that the following files are deleted from the directory:
   - `.git`, `.github`, `.gitignore`, `composer.json`, `composer.lock`, `CHANGELOG.md`, `CONTRIBUTING.md`, `README.md`, `LICENSE.md`, `CODE_OF_CONDUCT.md`, `CREDITS.md`, and `replace-namespace.sh` itself.
4. Confirm that the script does not throw errors and that the main functionality remains intact.

### Changelog Entry

> Removed - The `replace-namespace.sh` is now automatically deleted after namespace replacement.

### Credits

Props @ocean90, @gsarig, @faisal-alvi

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.