### PR TITLE
Fix translator errors and add WP version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ In your project's `composer.json`, add the following:
     ],
     "scripts": {
         "post-install-cmd": [
-            "./10up-lib/wp-compat-validation-tool/replace-namespace.sh <New_Name_Space>"
+            "./10up-lib/wp-compat-validation-tool/replace-namespace.sh <New_Name_Space> <Translation-Domain>"
         ],
         "post-update-cmd": [
-            "./10up-lib/wp-compat-validation-tool/replace-namespace.sh <New_Name_Space>"
+            "./10up-lib/wp-compat-validation-tool/replace-namespace.sh <New_Name_Space> <Translation-Domain>"
         ]
     },
     "extra": {
@@ -42,6 +42,9 @@ In your project's `composer.json`, add the following:
 
 Replace `<New_Name_Space>` with a unique namespace specific to your project.
 The `WP_Compat_Validation_Tools` namespace will be replaced by `<New_Name_Space>` to avoid namespace collisions in situations where multiple plugins use this package as their dependencies.
+
+Replace `<Translation-Domain>` with a unique translation domain specific to your project.
+This is usually the slug for your theme or plugin. The `wp-compat-validation-tool` translation domain will be replaced by `<Translation-Domain>`.
 
 ## Usage
 

--- a/replace-namespace.sh
+++ b/replace-namespace.sh
@@ -31,7 +31,7 @@ if [ -n "$TRANSLATION_DOMAIN" ]; then
 	find "$SCRIPT_DIR" -type f \( -name "*.php" -o -name "*.json" \) ! -name "$SCRIPT_NAME" | while read -r file; do
 		echo $file
 		# Replace the exact string when surrounded by either single or double quotes
-		perl -pi -e "s/(['\"])wp-compat-validation-tool\\1/$TRANSLATION_DOMAIN/g" "$file"
+		perl -pi -e "s/(['\"])wp-compat-validation-tool\\1/\\1$TRANSLATION_DOMAIN\\1/g" "$file"
 	done
 fi
 

--- a/replace-namespace.sh
+++ b/replace-namespace.sh
@@ -4,13 +4,20 @@
 SCRIPT_DIR="$(dirname "$0")"
 SCRIPT_NAME="$(basename "$0")"
 
-# Check for the required argument
-if [ "$#" -ne 1 ]; then
+# Check for the required first argument
+if [ -z "$1" ]; then
 	echo "Usage: $0 New_Namespace"
 	exit 1
 fi
 
 NEW_NAMESPACE="$1"
+
+# Check for the optional translation domain argument and set it if provided
+if [ -n "$2" ]; then
+	TRANSLATION_DOMAIN="$2"
+else
+	echo "No translation domain provided. Skipping translation domain replacement."
+fi
 
 # Use find to get all files recursively from the script's directory, excluding the script itself
 find "$SCRIPT_DIR" -type f \( -name "*.php" -o -name "*.json" \) ! -name "$SCRIPT_NAME" | while read -r file; do
@@ -18,5 +25,14 @@ find "$SCRIPT_DIR" -type f \( -name "*.php" -o -name "*.json" \) ! -name "$SCRIP
 	# Use perl for the replacement in each file
 	perl -pi -e "s/WP_Compat_Validation_Tool/$NEW_NAMESPACE/g" "$file"
 done
+
+# If a new translation domain was provided, replace the old one with the new one
+if [ -n "$TRANSLATION_DOMAIN" ]; then
+	find "$SCRIPT_DIR" -type f \( -name "*.php" -o -name "*.json" \) ! -name "$SCRIPT_NAME" | while read -r file; do
+		echo $file
+		# Replace the exact string when surrounded by either single or double quotes
+		perl -pi -e "s/(['\"])wp-compat-validation-tool\\1/$TRANSLATION_DOMAIN/g" "$file"
+	done
+fi
 
 cd 10up-lib/wp-compat-validation-tool && rm -rf .git .github .gitignore composer.json composer.lock CHANGELOG.md CONTRIBUTING.md README.md LICENSE.md CODE_OF_CONDUCT.md CREDITS.md replace-namespace.sh

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -118,13 +118,13 @@ class Validator {
 			switch ( $item_name ) {
 				case 'php_min_required_version':
 					if ( ! empty( $item_details['value'] ) && version_compare( phpversion(), $item_details['value'], '<' ) ) {
-						$this->messages[] = sprintf( esc_html__( 'The minimum PHP version required is %s' ), $item_details['value'] );
+						$this->messages[] = sprintf( __( 'The minimum PHP version required is %s', 'wp-compat-validation-tool' ), $item_details['value'] );
 					}
 					break;
 
 				case 'php_max_required_version':
 					if ( ! empty( $item_details['value'] ) && version_compare( phpversion(), $item_details['value'], '>' ) ) {
-						$this->messages[] = sprintf( esc_html__( 'The maximum PHP version supported is %s' ), $item_details['value'] );
+						$this->messages[] = sprintf( __( 'The maximum PHP version supported is %s', 'wp-compat-validation-tool' ), $item_details['value'] );
 					}
 					break;
 
@@ -149,7 +149,7 @@ class Validator {
 		<div class="notice notice-error">
 			<p>
 				<strong>
-					<?php printf( esc_html__( '%s error:' ), $this->checklist['plugin_name']['value'] ); ?>
+					<?php printf( esc_html__( '%s error:', 'wp-compat-validation-tool' ), $this->checklist['plugin_name']['value'] ); ?>
 				</strong>
 			</p>
 			<?php if ( count( $this->messages ) > 1 ) : ?>

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -1,6 +1,10 @@
 <?php
 namespace WP_Compat_Validation_Tool;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 class Validator {
 	/**
 	 * Array of checks.

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -157,7 +157,7 @@ class Validator {
 				<strong>
 					<?php
 						// translators: %s: Plugin name
-						printf( esc_html__( '%s error:', 'wp-compat-validation-tool' ), $this->checklist['plugin_name']['value'] );
+						printf( esc_html__( '%s error:', 'wp-compat-validation-tool' ), esc_html( $this->checklist['plugin_name']['value'] ) );
 					?>
 				</strong>
 			</p>

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -109,6 +109,27 @@ class Validator {
 	}
 
 	/**
+	 * Returns the current WordPress version.
+	 *
+	 * Returns an unmodified value of `$wp_version`. Some plugins modify the global
+	 * in an attempt to improve security through obscurity. This practice can cause
+	 * errors in WordPress, so the ability to get an unmodified version is needed.
+	 *
+	 * Ports the WordPress function `wp_get_wp_version()` available in WordPress 6.7.0 and later.
+	 *
+	 * @return string The current WordPress version.
+	 */
+	public function wp_get_wp_version() {
+		static $wp_version;
+
+		if ( ! isset( $wp_version ) ) {
+			require ABSPATH . WPINC . '/version.php';
+		}
+
+		return $wp_version;
+	}
+
+	/**
 	 * Returns true if the plugin meets all compatibility checks, false otherwise.
 	 *
 	 * @return boolean
@@ -131,6 +152,20 @@ class Validator {
 					if ( ! empty( $item_details['value'] ) && version_compare( phpversion(), $item_details['value'], '>' ) ) {
 						// translators: %s: PHP version
 						$this->messages[] = sprintf( __( 'The maximum PHP version supported is %s', 'wp-compat-validation-tool' ), $item_details['value'] );
+					}
+					break;
+
+				case 'wp_min_required_version':
+					if ( ! empty( $item_details['value'] ) && version_compare( $this->wp_get_wp_version(), $item_details['value'], '<' ) ) {
+						// translators: %s: WordPress version
+						$this->messages[] = sprintf( __( 'The minimum WordPress version required is %s', 'wp-compat-validation-tool' ), $item_details['value'] );
+					}
+					break;
+
+				case 'wp_max_required_version':
+					if ( ! empty( $item_details['value'] ) && version_compare( $this->wp_get_wp_version(), $item_details['value'], '>' ) ) {
+						// translators: %s: WordPress version
+						$this->messages[] = sprintf( __( 'The maximum WordPress version supported is %s', 'wp-compat-validation-tool' ), $item_details['value'] );
 					}
 					break;
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -118,12 +118,14 @@ class Validator {
 			switch ( $item_name ) {
 				case 'php_min_required_version':
 					if ( ! empty( $item_details['value'] ) && version_compare( phpversion(), $item_details['value'], '<' ) ) {
+						// translators: %s: PHP version
 						$this->messages[] = sprintf( __( 'The minimum PHP version required is %s', 'wp-compat-validation-tool' ), $item_details['value'] );
 					}
 					break;
 
 				case 'php_max_required_version':
 					if ( ! empty( $item_details['value'] ) && version_compare( phpversion(), $item_details['value'], '>' ) ) {
+						// translators: %s: PHP version
 						$this->messages[] = sprintf( __( 'The maximum PHP version supported is %s', 'wp-compat-validation-tool' ), $item_details['value'] );
 					}
 					break;
@@ -149,7 +151,10 @@ class Validator {
 		<div class="notice notice-error">
 			<p>
 				<strong>
-					<?php printf( esc_html__( '%s error:', 'wp-compat-validation-tool' ), $this->checklist['plugin_name']['value'] ); ?>
+					<?php
+						// translators: %s: Plugin name
+						printf( esc_html__( '%s error:', 'wp-compat-validation-tool' ), $this->checklist['plugin_name']['value'] );
+					?>
 				</strong>
 			</p>
 			<?php if ( count( $this->messages ) > 1 ) : ?>


### PR DESCRIPTION
### Description of the Change

This fixes a couple of things:

* Translator comments added for strings that include placeholders.
* Translation domain added as required by WPCS
* Adds a second parameter to `replace-namespace.sh` to replace the translation domain (making the file name inaccurate but maintaining back compat)
* Adds checks for the WordPress versions required by a plugin

Closes #11 
Closes #15 

### How to test the Change

I've used https://github.com/10up/simple-page-ordering/ for my testing

1. Checkout the SPO Branch https://github.com/10up/simple-page-ordering/pull/284
2. Run `composer i`
3. Ensure the namespace is correct
4. Ensure the translation domain is replaced with `simple-page-ordering`
5. In the main plugin file, specify a minimum version of WP to an unreleased version, say `9.5`
6. Visit the admin of the site
7. Ensure the message is displayed warning that the plugin is not supported.


### Changelog Entry
> Fixed - Add translator comments for strings containing placeholders
> Fixed - Add translator domain as required by WP Coding Standards & Plugin Repo
> Fixed - Add support for checking supported WordPress version.
> Added - The `replace-namespace.sh` script is now accepts a second argument to replace the translation domain.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
